### PR TITLE
Fix signature file deletion path

### DIFF
--- a/backend/controllers/memoController.js
+++ b/backend/controllers/memoController.js
@@ -93,7 +93,10 @@ class MemoController {
 
       // 如果有签名图片文件，也要删除
       if (deletedMemo.tester_signature_path) {
-        const filePath = path.join(__dirname, '..', deletedMemo.tester_signature_path);
+        const relativePath = deletedMemo.tester_signature_path.startsWith('/')
+          ? deletedMemo.tester_signature_path.slice(1)
+          : deletedMemo.tester_signature_path;
+        const filePath = path.join(__dirname, '..', relativePath);
         if (fs.existsSync(filePath)) {
           fs.unlinkSync(filePath);
         }


### PR DESCRIPTION
## Summary
- ensure signature deletion uses relative path to avoid failures when stored path begins with '/'

## Testing
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c819c794832ab48db368e6af3b9d